### PR TITLE
Add Zsolt (@rappizs) to `gh-jira-issue-sync-triagers` team

### DIFF
--- a/orgs/uwu-tools/gh-jira-issue-sync/teams.yaml
+++ b/orgs/uwu-tools/gh-jira-issue-sync/teams.yaml
@@ -22,6 +22,7 @@ teams:
     maintainers: []
     members:
     - lgecse
+    - rappizs
     privacy: closed
     repos:
       gh-jira-issue-sync: triage

--- a/orgs/uwu-tools/org.yaml
+++ b/orgs/uwu-tools/org.yaml
@@ -14,6 +14,7 @@ has_repository_projects: true
 location: ""
 members:
 - lgecse
+- rappizs
 members_can_create_repositories: false
 name: ""
 teams:


### PR DESCRIPTION
Added rappizs (@rappizs) to gh-jira-issue-sync, he'll help resolving pending issues around the tool.