### PR TITLE
workflows/production-sync: Set `min-admins` to 3

### DIFF
--- a/.github/workflows/production-sync.yml
+++ b/.github/workflows/production-sync.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           github-token-path: ./token
           config-path: orgs
-          min-admins: 4
+          min-admins: 3
           required-admins: "auggie-bot,cpanato,justaugustus"
           fix-org: true
           fix-org-members: true


### PR DESCRIPTION
Should fix failed production run in https://github.com/uwu-tools/.github/actions/runs/12125754634.
Follow-up to https://github.com/uwu-tools/.github/pull/52.