### PR TITLE
allstar: enable SARIF upload for scorecard policy

### DIFF
--- a/allstar/scorecard.yaml
+++ b/allstar/scorecard.yaml
@@ -22,3 +22,5 @@ checks:
 - "Token-Permissions"
 - "Vulnerabilities"
 - "Webhooks"
+upload:
+  sarif: true


### PR DESCRIPTION
## Summary

- Enable SARIF upload in the Allstar Scorecard policy config

## Context

Testing the evidence upload feature from [ossf/allstar#796](https://github.com/ossf/allstar/pull/796). This adds `upload: {sarif: true}` to the existing Scorecard policy config so that scan results are uploaded to each repo's Security > Code Scanning tab.

## Test plan

- [ ] Run self-hosted Allstar with `-once` flag against this org
- [ ] Verify SARIF appears in repo Security tabs
- [ ] Revert after testing is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)