### PR TITLE
ci: add Allstar enforcement action with SARIF upload

### DIFF
--- a/.github/workflows/allstar.yml
+++ b/.github/workflows/allstar.yml
@@ -1,0 +1,58 @@
+---
+name: Allstar (Scorecard GitHub App)
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Daily at 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch: {}
+
+permissions: {}
+
+env:
+  ARTIFACT_DIR: /tmp/artifacts
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Allstar source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ossf/allstar
+          ref: evidence-upload
+          persist-credentials: false
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+      - name: Build Allstar
+        run: go build -o allstar ./cmd/allstar/
+      - name: Create artifact directory
+        run: mkdir "$ARTIFACT_DIR"
+      - name: Run Allstar policy check
+        env:
+          NOTICE_PING_DURATION_HOURS: '168'
+          DO_NOTHING_ON_OPT_OUT: 'true'
+          ALLSTAR_LOG_LEVEL: info
+          KEY_SECRET: direct
+          APP_ID: ${{ vars.APP_ID }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        run: |
+          ./allstar -once -policy "OpenSSF Scorecard" 2> "$ARTIFACT_DIR/allstar.log" | tee "$ARTIFACT_DIR/allstar.out"
+          if [ -s "$ARTIFACT_DIR/allstar.log" ]; then
+            echo "==== Errors ===="
+            cat "$ARTIFACT_DIR/allstar.log"
+          fi
+      - name: Archive Allstar results
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: allstar-scan
+          path: ${{ env.ARTIFACT_DIR }}


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to run Allstar with SARIF upload from the `evidence-upload` branch

## Context

Testing the evidence upload feature from [ossf/allstar](https://github.com/ossf/allstar) as a GitHub Action deployment.

## Setup required

Before merging, create a `prod` environment on this repo:

1. Go to **Settings > Environments > New environment** → name it `prod`
2. Under **Environment variables**, add `APP_ID` with the GitHub App's ID
3. Under **Environment secrets**, add `PRIVATE_KEY` with the contents of the App private key PEM

## Test plan

- [ ] Create `prod` environment with App secrets
- [ ] Merge this PR
- [ ] Verify workflow runs via Actions tab
- [ ] Verify SARIF appears in repo Security tabs
- [ ] Clean up after testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)