### PR TITLE
ci: Add `scorecard-monitor` integration with Allstar results

### DIFF
--- a/.github/workflows/allstar.yml
+++ b/.github/workflows/allstar.yml
@@ -78,8 +78,8 @@ jobs:
         id: scorecard-monitor
         with:
           results-path: ${{ env.ARTIFACT_DIR }}/results.json
-          database: reporting/database.json
-          report: reporting/scorecard-report.md
+          database: reports/database.json
+          report: reports/scorecard-report.md
           auto-commit: false
           auto-push: false
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/allstar.yml
+++ b/.github/workflows/allstar.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ossf/allstar
-          ref: evidence-upload
+          ref: results-json-output
           persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -45,7 +45,7 @@ jobs:
           APP_ID: ${{ vars.APP_ID }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         run: |
-          ./allstar -once -policy "OpenSSF Scorecard" 2> "$ARTIFACT_DIR/allstar.log" | tee "$ARTIFACT_DIR/allstar.out"
+          ./allstar -once -policy "OpenSSF Scorecard" -results-file "$ARTIFACT_DIR/results.json" 2> "$ARTIFACT_DIR/allstar.log" | tee "$ARTIFACT_DIR/allstar.out"
           if [ -s "$ARTIFACT_DIR/allstar.log" ]; then
             echo "==== Errors ===="
             cat "$ARTIFACT_DIR/allstar.log"
@@ -56,3 +56,40 @@ jobs:
         with:
           name: allstar-scan
           path: ${{ env.ARTIFACT_DIR }}
+
+  monitor:
+    runs-on: ubuntu-latest
+    needs: scan
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Download scan artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: allstar-scan
+          path: ${{ env.ARTIFACT_DIR }}
+      - name: OpenSSF Scorecard Monitor
+        uses: ossf/scorecard-monitor@local-results # TODO: pin to release once merged
+        id: scorecard-monitor
+        with:
+          results-path: ${{ env.ARTIFACT_DIR }}/results.json
+          database: reporting/database.json
+          report: reporting/scorecard-report.md
+          auto-commit: false
+          auto-push: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update Scorecard Monitor report
+          title: Update Scorecard Monitor report
+          body: Automated Scorecard report update from Allstar scan.
+          base: main
+          branch: scorecard-report-update
+          delete-branch: true


### PR DESCRIPTION
## Summary

Update the Allstar workflow to produce a Scorecard results file and feed it into scorecard-monitor for dashboard reporting via PR.

## Changes

- Allstar ref updated from `evidence-upload` to `results-json-output` (adds `-results-file` flag)
- Allstar run produces `results.json` (Scorecard JSON v2 format) as an artifact
- New `monitor` job runs scorecard-monitor with `results-path` input to consume the results
- Uses `peter-evans/create-pull-request` for human review of report updates

## Related PRs

- [ossf/allstar#800](https://github.com/ossf/allstar/pull/800) — `-results-file` flag (producing end)
- [ossf/scorecard-monitor#90](https://github.com/ossf/scorecard-monitor/pull/90) — `results-path` input (consuming end)

## Test plan

- [ ] Merge and trigger via workflow_dispatch
- [ ] Verify scan job produces results.json artifact
- [ ] Verify monitor job creates a PR with scorecard-report.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)